### PR TITLE
Fix system framework localizations and add notification

### DIFF
--- a/Classes/BundleLocalization.h
+++ b/Classes/BundleLocalization.h
@@ -23,6 +23,8 @@
 #import <Foundation/Foundation.h>
 #import "NSBundle+Localization.h"
 
+extern NSString *const kBundleLocalizationChangedNotification;
+
 @interface BundleLocalization : NSObject
 
 + (BundleLocalization*) sharedInstance;

--- a/Classes/BundleLocalization.m
+++ b/Classes/BundleLocalization.m
@@ -23,6 +23,8 @@
 #import "BundleLocalization.h"
 #import "NSBundle+Localization.h"
 
+NSString *const kBundleLocalizationChangedNotification = @"kBundleLocalizationChangedNotification";
+
 
 @implementation BundleLocalization
 {
@@ -64,6 +66,13 @@
         }
         selectedLanguage = lang;
     }
+
+    // Set the language so system frameworks will be localized also.
+    // This requires an app restart to take effect.
+    [[NSUserDefaults standardUserDefaults] setObject:@[lang] forKey:@"AppleLanguages"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:kBundleLocalizationChangedNotification object:nil];
 }
 
 - (NSString*) language{

--- a/Classes/NSBundle+Localization.m
+++ b/Classes/NSBundle+Localization.m
@@ -55,9 +55,17 @@
 
 #pragma mark - Method Swizzling
 
--(NSString*) customLocaLizedStringForKey:(NSString *)key value:(NSString *)value table:(NSString *)tableName
+- (NSString *) customLocaLizedStringForKey:(NSString *)key value:(NSString *)value table:(NSString *)tableName
 {
-    NSBundle* bundle = [BundleLocalization sharedInstance].localizationBundle;
+    NSBundle *bundle = [BundleLocalization sharedInstance].localizationBundle;
+    NSString *bundleString = [self.bundleURL.path stringByReplacingOccurrencesOfString:@"/private" withString:@""];
+
+    // This is not the app bundle (i.e. a system framework such as UIKit, or MediaPlayer)
+    if ([bundle.bundleURL.path rangeOfString:bundleString].location == NSNotFound)
+    {
+        return [self customLocaLizedStringForKey:key value:value table:tableName];
+    }
+
     return [bundle customLocaLizedStringForKey:key value:value table:tableName];
 }
 


### PR DESCRIPTION
- Fix issue with system frameworks not loading localized strings (https://github.com/cmaftuleac/BundleLocalization/issues/1)
- Set "AppleLanguages" user defaults to allow system frameworks to load localized strings in the same language that is set using setLanguage:
- Send a notification when the localization is changed using setLanguage:
